### PR TITLE
DP-320: Add custom action hook for updating audio files for CDS

### DIFF
--- a/classes/npr_json.php
+++ b/classes/npr_json.php
@@ -372,6 +372,14 @@ function npr_cds_to_json( $post ): bool|string {
 			$audio_enc->href = $audio_guid;
 			$audio_enc->type = $audio->post_mime_type;
 
+			/**
+			 * Allows modification of audio file before it is added to the story object.
+			 *
+			 * @param WP_Post  $audio     The WP attachment object.
+			 * @param stdClass $audio_enc The enclosure object to be added.
+			 */
+			do_action_ref_array( 'cds_audio_override', [ &$audio, &$audio_enc ] );
+
 			$audio_asset->enclosures = [ $audio_enc ];
 			$story->assets->{$audio_asset_id} = $audio_asset;
 

--- a/classes/npr_json.php
+++ b/classes/npr_json.php
@@ -373,7 +373,7 @@ function npr_cds_to_json( $post ): bool|string {
 			$audio_enc->type = $audio->post_mime_type;
 
 			/**
-			 * Allows modification of audio file before it is added to the story object.
+			 * DP-320: Allows modification of audio file before it is added to the story object.
 			 *
 			 * @param WP_Post  $audio     The WP attachment object.
 			 * @param stdClass $audio_enc The enclosure object to be added.


### PR DESCRIPTION
This work adds a custom action hook to handle the audio fix to send encoded audio to the CDS. 