### PR TITLE
DP-593: Update CDS plugin from version 1.3.5 to 1.3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ NPR Stories having been retrieved
 ### V.1.3.7
 * Implementing filters for push post type, custom title, custom body, and custom byline (h/t @justinferrell for the suggestion)
 
+### V.1.3.6.1
+* Added a check to prevent fatal error on collections with no rels (h/t @tamw-wnet for the fix)
+
 ### V.1.3.6
 * Fixed bug that prevented category selection for posts imported via Get Multi queries from saving properly (h/t @xpn-bdivver for the fix)
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A collection of tools for publishing from and to NPR's Content Distribution Serv
 - Requires at least: 4.0
 - Tested up to: 6.7
 - Requires PHP: 8.0
-- Version: 1.3.5
-- Stable tag: 1.3.5
+- Version: 1.3.6
+- Stable tag: 1.3.6
 - Author: Open Public Media
 - Author URI: https://github.com/OpenPublicMedia/
 - License: GPLv2
@@ -77,6 +77,10 @@ NPR Stories having been retrieved
 
 ## Changelog
 <!-- copy from readme.txt to here -->
+### V.1.3.6
+* Fixed bug that prevented category selection for posts imported via Get Multi queries from saving properly (h/t @xpn-bdivver for the fix)
+* Adding support for pushing multiple post types to the CDS (h/t @justinferrell for the suggestion)
+
 ### V.1.3.5
 * Switched Yoast plugin detection to work better in multisite setups (h/t @tamw-wnet for the fix)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ NPR Stories having been retrieved
 <!-- copy from readme.txt to here -->
 ### V.1.3.6
 * Fixed bug that prevented category selection for posts imported via Get Multi queries from saving properly (h/t @xpn-bdivver for the fix)
-* Adding support for pushing multiple post types to the CDS (h/t @justinferrell for the suggestion)
 
 ### V.1.3.5
 * Switched Yoast plugin detection to work better in multisite setups (h/t @tamw-wnet for the fix)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A collection of tools for publishing from and to NPR's Content Distribution Serv
 - Requires at least: 4.0
 - Tested up to: 6.7
 - Requires PHP: 8.0
-- Version: 1.3.6
-- Stable tag: 1.3.6
+- Version: 1.3.7
+- Stable tag: 1.3.7
 - Author: Open Public Media
 - Author URI: https://github.com/OpenPublicMedia/
 - License: GPLv2
@@ -77,6 +77,9 @@ NPR Stories having been retrieved
 
 ## Changelog
 <!-- copy from readme.txt to here -->
+### V.1.3.7
+* Implementing filters for push post type, custom title, custom body, and custom byline (h/t @justinferrell for the suggestion)
+
 ### V.1.3.6
 * Fixed bug that prevented category selection for posts imported via Get Multi queries from saving properly (h/t @xpn-bdivver for the fix)
 

--- a/classes/NPR_CDS_WP.php
+++ b/classes/NPR_CDS_WP.php
@@ -635,6 +635,9 @@ class NPR_CDS_WP {
 				}
 				if ( !empty( $story->collections ) && $import_tags === '1' ) {
 					foreach ( $story->collections as $collect ) {
+						if ( !isset( $collect->rels ) ) {
+							continue;
+						}
 						if ( in_array( 'topic', $collect->rels ) || in_array( 'category', $collect->rels ) ) {
 
 							/**

--- a/classes/npr_json.php
+++ b/classes/npr_json.php
@@ -62,7 +62,7 @@ function npr_cds_to_json( $post ): bool|string {
 	/*
 	 * Custom content
 	 */
-	$custom_content_meta = get_option( 'npr_cds_mapping_body' );
+	$custom_content_meta = npr_cds_get_mapping_body( $post );
 	if ( !empty( $custom_content_meta ) && $custom_content_meta === '#NONE' ) {
 		$custom_content_meta = 'npr_story_content';
 		update_option( 'npr_cds_mapping_body', $custom_content_meta );
@@ -113,7 +113,7 @@ function npr_cds_to_json( $post ): bool|string {
 	/*
 	 * Custom title
 	 */
-	$custom_title_meta = get_option( 'npr_cds_mapping_title' );
+	$custom_title_meta = npr_cds_get_mapping_title( $post );
 	if (
 		$use_custom
 		&& !empty( $custom_title_meta )
@@ -133,7 +133,7 @@ function npr_cds_to_json( $post ): bool|string {
 	 * If no cool things are going on, just send the display name for the post_author field.
 	 */
 	$bylines = [];
-	$custom_byline_meta = get_option( 'npr_cds_mapping_byline' );
+	$custom_byline_meta = npr_cds_get_mapping_byline( $post );
 	// Custom field mapping byline
 	if (
 		$use_custom

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"type"       : "wordpress-plugin",
 	"license"    : "GPL-2.0+",
 	"dist": {
-		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.3.5.zip",
+		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.3.6.zip",
 		"type": "zip"
 	},
 	"authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"type"       : "wordpress-plugin",
 	"license"    : "GPL-2.0+",
 	"dist": {
-		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.3.6.zip",
+		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.3.7.zip",
 		"type": "zip"
 	},
 	"authors": [

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -80,3 +80,31 @@ Aside from the settings presented inside the WordPress dashboard, there are also
   * `$service_id (string)`: a comma-separated list of service IDs, which are individually formatted as `s###`
   * `$post (WP_Post)`: the WordPress Post object that is being pushed to the CDS
 * **Return**: `$service_id`
+
+## `npr_cds_push_post_type_filter`
+* **Function**: Allow a site to modify the post type being pushed to the CDS on a case-by-case basis. This allows for sites to push more than one post type while keeping one as their primary. If the metadata fields for the secondary post type differ from the primary, the site can use the mapping filters below in conjunction.
+* **Arguments**
+  * `$option (string)`: the name of the current push post type
+  * `$post (WP_Post)`: the WordPress Post object that is being pushed to the CDS
+* **Return**: `$option`
+
+## `npr_cds_mapping_title_filter`
+* **Function**: Allow a site to modify which metadata field is being used to supply the title for the post. This is intended for use in conjunction with the `npr_cds_push_post_type_filter` to support a secondary post type for pushing to the CDS.
+* **Arguments**
+  * `$option (string)`: the name of the current metadata field
+  * `$post (WP_Post)`: the WordPress Post object that is being pushed to the CDS
+* **Return**: `$option`
+
+## `npr_cds_mapping_body_filter`
+* **Function**: Allow a site to modify which metadata field is being used to supply the body for the post. This is intended for use in conjunction with the `npr_cds_push_post_type_filter` to support a secondary post type for pushing to the CDS.
+* **Arguments**
+  * `$option (string)`: the name of the current metadata field
+  * `$post (WP_Post)`: the WordPress Post object that is being pushed to the CDS
+* **Return**: `$option`
+
+## `npr_cds_mapping_byline_filter`
+* **Function**: Allow a site to modify which metadata field is being used to supply the byline for the post. This is intended for use in conjunction with the `npr_cds_push_post_type_filter` to support a secondary post type for pushing to the CDS.
+* **Arguments**
+  * `$option (string)`: the name of the current metadata field
+  * `$post (WP_Post)`: the WordPress Post object that is being pushed to the CDS
+* **Return**: `$option`

--- a/npr_cds.php
+++ b/npr_cds.php
@@ -196,7 +196,7 @@ function npr_cds_activate(): void {
 	}
 	$push_post = get_option( 'ds_npr_push_post_type' );
 	if ( !empty( $push_post ) ) {
-		update_option( 'npr_cds_push_post_type', [ $push_post ] );
+		update_option( 'npr_cds_push_post_type', $push_post );
 	}
 	$org_id = get_option( 'ds_npr_api_org_id' );
 	if ( !empty( $org_id ) ) {
@@ -381,20 +381,16 @@ function npr_cds_create_post_type(): void {
  */
 function npr_cds_add_meta_boxes(): void {
 	$screen = get_current_screen();
-	$push_post_type = get_option( 'npr_cds_push_post_type', [ 'post' ] );
-	if ( !is_array( $push_post_type ) ) {
-		$push_post_type = [ $push_post_type ];
-		update_option( 'npr_cds_push_post_type', $push_post_type );
-	}
+	$push_post_type = get_option( 'npr_cds_push_post_type' ) ?: 'post';
 	$push_url = get_option( 'npr_cds_push_url' );
-	if ( in_array( $screen->id, $push_post_type ) ) {
+	if ( $screen->id == $push_post_type ) {
 		if ( !empty( $push_url ) ) {
 			global $post;
 			add_meta_box(
 				'npr_cds_document_meta',
 				'NPR CDS',
 				'npr_cds_publish_meta_box',
-				$screen->id,
+				$push_post_type,
 				'side',
 				'core'
 			);
@@ -405,7 +401,7 @@ function npr_cds_add_meta_boxes(): void {
 				'npr_cds_document_meta',
 				'NPR CDS',
 				'npr_cds_publish_meta_box_prompt',
-				$screen->id,
+				$push_post_type,
 				'side',
 				'core'
 			);
@@ -436,7 +432,7 @@ function npr_cds_esc_html( $string ): string {
 function npr_cds_add_header_meta(): void {
 	global $wp_query;
 	if ( !is_home() && !is_404() &&
-	     ( get_post_type() === get_option( 'npr_cds_pull_post_type' ) || in_array( get_post_type(), get_option( 'npr_cds_push_post_type' ) ) )
+		( get_post_type() === get_option( 'npr_cds_pull_post_type' ) || get_post_type() === get_option( 'npr_cds_push_post_type' ) )
 	) {
 		$id = $wp_query->queried_object_id;
 		$npr_story_id = get_post_meta( $id, NPR_STORY_ID_META_KEY, 1 );
@@ -483,16 +479,16 @@ function npr_cds_add_header_meta(): void {
 				wp_enqueue_style( 'npr-splide-css', NPR_CDS_PLUGIN_URL . 'assets/css/splide.min.css' );
 			}
 			?>
-			<meta name="datePublished" content="<?php echo esc_attr( get_the_date( 'c', $id ) ); ?>" />
-			<meta name="story_id" content="<?php echo esc_attr( $npr_story_id ); ?>" />
-			<meta name="has_audio" content="<?php echo esc_attr( $has_audio ); ?>" />
-			<meta name="org_id" content="<?php echo esc_attr( get_option( 'npr_cds_org_id' ) ); ?>" />
-			<meta name="category" content="<?php echo esc_attr( $primary_cat ); ?>" />
-			<meta name="author" content="<?php echo esc_attr( $byline ); ?>" />
-			<meta name="programs" content="none" />
-			<meta name="wordCount" content="<?php echo esc_attr( $word_count ); ?>" />
-			<meta name="keywords" content="<?php echo esc_html( implode( ',', $keywords ) ); ?>" />
-			<?php
+		<meta name="datePublished" content="<?php echo esc_attr( get_the_date( 'c', $id ) ); ?>" />
+		<meta name="story_id" content="<?php echo esc_attr( $npr_story_id ); ?>" />
+		<meta name="has_audio" content="<?php echo esc_attr( $has_audio ); ?>" />
+		<meta name="org_id" content="<?php echo esc_attr( get_option( 'npr_cds_org_id' ) ); ?>" />
+		<meta name="category" content="<?php echo esc_attr( $primary_cat ); ?>" />
+		<meta name="author" content="<?php echo esc_attr( $byline ); ?>" />
+		<meta name="programs" content="none" />
+		<meta name="wordCount" content="<?php echo esc_attr( $word_count ); ?>" />
+		<meta name="keywords" content="<?php echo esc_html( implode( ',', $keywords ) ); ?>" />
+<?php
 		}
 	}
 }

--- a/npr_cds.php
+++ b/npr_cds.php
@@ -3,7 +3,7 @@
  * Plugin Name: NPR Content Distribution Service
  * Plugin URI: https://github.com/OpenPublicMedia/npr-cds-wordpress
  * Description: A collection of tools for reusing content from NPR.org, now maintained and updated by NPR member station developers
- * Version: 1.3.6
+ * Version: 1.3.7
  * Requires at least: 4.0
  * Requires PHP: 8.0
  * Author: Open Public Media

--- a/npr_cds.php
+++ b/npr_cds.php
@@ -381,11 +381,11 @@ function npr_cds_create_post_type(): void {
  */
 function npr_cds_add_meta_boxes(): void {
 	$screen = get_current_screen();
-	$push_post_type = get_option( 'npr_cds_push_post_type' ) ?: 'post';
+	global $post;
+	$push_post_type = npr_cds_get_push_post_type( $post );
 	$push_url = get_option( 'npr_cds_push_url' );
 	if ( $screen->id == $push_post_type ) {
 		if ( !empty( $push_url ) ) {
-			global $post;
 			add_meta_box(
 				'npr_cds_document_meta',
 				'NPR CDS',
@@ -396,7 +396,6 @@ function npr_cds_add_meta_boxes(): void {
 			);
 			add_action( 'admin_enqueue_scripts', 'npr_cds_publish_meta_box_assets' );
 		} else {
-			global $post;
 			add_meta_box(
 				'npr_cds_document_meta',
 				'NPR CDS',
@@ -430,9 +429,9 @@ function npr_cds_esc_html( $string ): string {
 }
 
 function npr_cds_add_header_meta(): void {
-	global $wp_query;
+	global $wp_query, $post;
 	if ( !is_home() && !is_404() &&
-		( get_post_type() === get_option( 'npr_cds_pull_post_type' ) || get_post_type() === get_option( 'npr_cds_push_post_type' ) )
+		( get_post_type() === get_option( 'npr_cds_pull_post_type' ) || get_post_type() === npr_cds_get_push_post_type( $post ) )
 	) {
 		$id = $wp_query->queried_object_id;
 		$npr_story_id = get_post_meta( $id, NPR_STORY_ID_META_KEY, 1 );
@@ -506,6 +505,37 @@ function npr_cds_filter_yoast_canonical( $canonical ) {
 }
 add_filter( 'wpseo_canonical', 'npr_cds_filter_yoast_canonical' );
 
+function npr_cds_get_push_post_type( $post = null ): string {
+	$option = get_option( 'npr_cds_post_type', 'post' );
+	if ( has_filter( 'npr_cds_push_post_type_filter' ) ) {
+		$option = apply_filters( 'npr_cds_push_post_type_filter', $option, $post );
+	}
+	return $option;
+}
+
+function npr_cds_get_mapping_title( $post ): string {
+	$option = get_option( 'npr_cds_mapping_title' );
+	if ( has_filter( 'npr_cds_mapping_title_filter' ) ) {
+		$option = apply_filters( 'npr_cds_mapping_title_filter', $option, $post );
+	}
+	return $option;
+}
+
+function npr_cds_get_mapping_body( $post ): string {
+	$option = get_option( 'npr_cds_mapping_body' );
+	if ( has_filter( 'npr_cds_mapping_body_filter' ) ) {
+		$option = apply_filters( 'npr_cds_mapping_body_filter', $option, $post );
+	}
+	return $option;
+}
+
+function npr_cds_get_mapping_byline( $post ): string {
+	$option = get_option( 'npr_cds_mapping_byline' );
+	if ( has_filter( 'npr_cds_mapping_byline_filter' ) ) {
+		$option = apply_filters( 'npr_cds_mapping_byline_filter', $option, $post );
+	}
+	return $option;
+}
 /* add_action( 'rest_api_init', function() {
 	register_rest_route( 'npr-cds/v1', '/notifications', [
 		'methods'  => 'POST',

--- a/push_story.php
+++ b/push_story.php
@@ -21,7 +21,7 @@ function npr_cds_push( int $post_ID, WP_Post $post ): void {
 		npr_cds_error_log( 'Not pushing the story with post_ID ' . $post_ID . ' to the NPR CDS because it was retrieved from the CDS' );
 		return;
 	}
-	$push_post_type = get_option( 'npr_cds_push_post_type', 'post' );
+	$push_post_type = npr_cds_get_push_post_type( $post );
 
 	//if the push url isn't set, don't even try to push.
 	$push_url = get_option( 'npr_cds_push_url' );
@@ -53,7 +53,7 @@ function npr_cds_push( int $post_ID, WP_Post $post ): void {
 		// Get the list of post meta keys available for this post.
 		$post_metas = get_post_custom_keys( $post->ID );
 
-		$custom_content_meta = get_option( 'npr_cds_mapping_body' );
+		$custom_content_meta = npr_cds_get_mapping_body( $post );
 		$body_field = $custom_content_meta;
 		if ( !empty( $custom_content_meta ) && $custom_content_meta !== '#NONE#' && in_array( $custom_content_meta, $post_metas, true ) ) {
 			$content = get_post_meta( $post->ID, $custom_content_meta, true );
@@ -90,7 +90,7 @@ function npr_cds_delete( int $post_ID ): void {
 			403
 		);
 	}
-	$push_post_type = get_option( 'npr_cds_push_post_type', 'post' );
+	$push_post_type = npr_cds_get_push_post_type( get_post( $post_ID ) );
 
 	$api_id = get_post_meta( $post_ID, NPR_STORY_ID_META_KEY, true );
 
@@ -154,10 +154,7 @@ function npr_cds_get_post_meta_keys( string $post_type = 'post' ): array {
 }
 
 function npr_cds_bulk_action_push_dropdown(): void {
-	$push_post_type = get_option( 'npr_cds_push_post_type' );
-	if ( empty( $push_post_type ) ) {
-		$push_post_type = 'post';
-	}
+	$push_post_type = npr_cds_get_push_post_type();
 
 	$push_url = get_option( 'npr_cds_push_url' );
 	global $post_type;
@@ -223,7 +220,7 @@ function npr_cds_save_send_to_cds( Int $post_ID ): bool {
 	if ( !isset( $_POST['npr_cds_send_nonce'] ) || !wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['npr_cds_send_nonce'] ) ), 'npr_cds-' . $post_ID ) ) return false;
 	global $post;
 
-	if ( get_post_type( $post ) !== get_option( 'npr_cds_push_post_type' ) ) return false;
+	if ( get_post_type( $post ) !== npr_cds_get_push_post_type( $post ) ) return false;
 	$value = ( isset( $_POST['send_to_cds'] ) && $_POST['send_to_cds'] == 1 ) ? 1 : 0;
 
 	// see historical note
@@ -249,7 +246,7 @@ function npr_cds_save_send_to_one( int $post_ID ): bool {
 
 	global $post;
 
-	if ( get_post_type( $post ) !== get_option( 'npr_cds_push_post_type' ) ) return false;
+	if ( get_post_type( $post ) !== npr_cds_get_push_post_type( $post ) ) return false;
 	$value = (
 		isset( $_POST['_send_to_one'] )
 		&& $_POST['_send_to_one'] == 1
@@ -279,7 +276,7 @@ function npr_cds_save_nprone_featured( int $post_ID ): bool {
 
 	global $post;
 
-	if ( get_post_type( $post ) != get_option( 'npr_cds_push_post_type' ) ) return false;
+	if ( get_post_type( $post ) != npr_cds_get_push_post_type( $post ) ) return false;
 	$value = (
 		isset( $_POST['_nprone_featured'] )
 		&& $_POST['_nprone_featured'] == 1
@@ -313,7 +310,7 @@ function npr_cds_save_datetime( int $post_ID ): bool {
 
 	global $post;
 
-	if ( get_post_type( $post ) != get_option( 'npr_cds_push_post_type' ) ) return false;
+	if ( get_post_type( $post ) != npr_cds_get_push_post_type( $post ) ) return false;
 
 	$date = ( isset( $_POST['nprone-expiry-datetime'] ) ) ? sanitize_text_field( $_POST['nprone-expiry-datetime'] ) : '';
 

--- a/push_story.php
+++ b/push_story.php
@@ -21,18 +21,14 @@ function npr_cds_push( int $post_ID, WP_Post $post ): void {
 		npr_cds_error_log( 'Not pushing the story with post_ID ' . $post_ID . ' to the NPR CDS because it was retrieved from the CDS' );
 		return;
 	}
-	$push_post_type = get_option( 'npr_cds_push_post_type', [ 'post' ] );
-	if ( !is_array( $push_post_type ) ) {
-		$push_post_type = [ $push_post_type ];
-		update_option( 'npr_cds_push_post_type', $push_post_type );
-	}
+	$push_post_type = get_option( 'npr_cds_push_post_type', 'post' );
 
 	//if the push url isn't set, don't even try to push.
 	$push_url = get_option( 'npr_cds_push_url' );
 
 	if ( !empty ( $push_url ) ) {
 		// For now, only submit the sort of post that is the push post type, and then only if published
-		if ( !in_array( $post->post_type, $push_post_type ) || $post->post_status !== 'publish' ) {
+		if ( $post->post_type !== $push_post_type || $post->post_status !== 'publish' ) {
 			return;
 		}
 		$send_to_cds = get_post_meta( $post->ID, '_send_to_nprone', true );
@@ -94,18 +90,14 @@ function npr_cds_delete( int $post_ID ): void {
 			403
 		);
 	}
-	$push_post_type = get_option( 'npr_cds_push_post_type', [ 'post' ] );
-	if ( !is_array( $push_post_type ) ) {
-		$push_post_type = [ $push_post_type ];
-		update_option( 'npr_cds_push_post_type', $push_post_type );
-	}
+	$push_post_type = get_option( 'npr_cds_push_post_type', 'post' );
 
 	$api_id = get_post_meta( $post_ID, NPR_STORY_ID_META_KEY, true );
 
 	$post = get_post( $post_ID );
 	//if the push url isn't set, don't even try to delete.
 	$push_url = get_option( 'npr_cds_push_url' );
-	if ( in_array( $post->post_type, $push_post_type ) && !empty( $push_url ) && !empty( $api_id ) ) {
+	if ( $post->post_type == $push_post_type && !empty( $push_url ) && !empty( $api_id ) ) {
 		$api = new NPR_CDS_WP();
 		$retrieved = get_post_meta( $post_ID, NPR_RETRIEVED_STORY_META_KEY, true );
 
@@ -162,16 +154,16 @@ function npr_cds_get_post_meta_keys( string $post_type = 'post' ): array {
 }
 
 function npr_cds_bulk_action_push_dropdown(): void {
-	$push_post_type = get_option( 'npr_cds_push_post_type', [ 'post' ] );
-	if ( !is_array( $push_post_type ) ) {
-		$push_post_type = [ $push_post_type ];
-		update_option( 'npr_cds_push_post_type', $push_post_type );
+	$push_post_type = get_option( 'npr_cds_push_post_type' );
+	if ( empty( $push_post_type ) ) {
+		$push_post_type = 'post';
 	}
+
 	$push_url = get_option( 'npr_cds_push_url' );
 	global $post_type;
 
 	//make sure we have the right post_type and that the push URL is filled in, so we know we want to push this post-type
-	if ( in_array( $post_type, $push_post_type ) && !empty( $push_url ) ) {
+	if ( $post_type == $push_post_type && !empty( $push_url ) ) {
 		printf(
 			'<script>jQuery(document).ready(function($) {$("<option>").val("pushNprStory").text("%s").appendTo("select[name=\'action\']");$("<option>").val("pushNprStory").text("%s").appendTo("select[name=\'action2\']");});</script>',
 			__( 'Push Story to NPR', 'npr-content-distribution-service' ),
@@ -231,12 +223,7 @@ function npr_cds_save_send_to_cds( Int $post_ID ): bool {
 	if ( !isset( $_POST['npr_cds_send_nonce'] ) || !wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['npr_cds_send_nonce'] ) ), 'npr_cds-' . $post_ID ) ) return false;
 	global $post;
 
-	$push_post_type = get_option( 'npr_cds_push_post_type', [ 'post' ] );
-	if ( !is_array( $push_post_type ) ) {
-		$push_post_type = [ $push_post_type ];
-		update_option( 'npr_cds_push_post_type', $push_post_type );
-	}
-	if ( !in_array( get_post_type( $post ), $push_post_type ) ) return false;
+	if ( get_post_type( $post ) !== get_option( 'npr_cds_push_post_type' ) ) return false;
 	$value = ( isset( $_POST['send_to_cds'] ) && $_POST['send_to_cds'] == 1 ) ? 1 : 0;
 
 	// see historical note
@@ -262,12 +249,7 @@ function npr_cds_save_send_to_one( int $post_ID ): bool {
 
 	global $post;
 
-	$push_post_type = get_option( 'npr_cds_push_post_type', [ 'post' ] );
-	if ( !is_array( $push_post_type ) ) {
-		$push_post_type = [ $push_post_type ];
-		update_option( 'npr_cds_push_post_type', $push_post_type );
-	}
-	if ( !in_array( get_post_type( $post ), $push_post_type ) ) return false;
+	if ( get_post_type( $post ) !== get_option( 'npr_cds_push_post_type' ) ) return false;
 	$value = (
 		isset( $_POST['_send_to_one'] )
 		&& $_POST['_send_to_one'] == 1
@@ -297,12 +279,7 @@ function npr_cds_save_nprone_featured( int $post_ID ): bool {
 
 	global $post;
 
-	$push_post_type = get_option( 'npr_cds_push_post_type', [ 'post' ] );
-	if ( !is_array( $push_post_type ) ) {
-		$push_post_type = [ $push_post_type ];
-		update_option( 'npr_cds_push_post_type', $push_post_type );
-	}
-	if ( !in_array( get_post_type( $post ), $push_post_type ) ) return false;
+	if ( get_post_type( $post ) != get_option( 'npr_cds_push_post_type' ) ) return false;
 	$value = (
 		isset( $_POST['_nprone_featured'] )
 		&& $_POST['_nprone_featured'] == 1
@@ -336,12 +313,7 @@ function npr_cds_save_datetime( int $post_ID ): bool {
 
 	global $post;
 
-	$push_post_type = get_option( 'npr_cds_push_post_type', [ 'post' ] );
-	if ( !is_array( $push_post_type ) ) {
-		$push_post_type = [ $push_post_type ];
-		update_option( 'npr_cds_push_post_type', $push_post_type );
-	}
-	if ( !in_array( get_post_type( $post ), $push_post_type ) ) return false;
+	if ( get_post_type( $post ) != get_option( 'npr_cds_push_post_type' ) ) return false;
 
 	$date = ( isset( $_POST['nprone-expiry-datetime'] ) ) ? sanitize_text_field( $_POST['nprone-expiry-datetime'] ) : '';
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Tags: npr, news, public radio, api
 Requires at least: 4.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Version: 1.3.5
-Stable tag: 1.3.5
+Version: 1.3.6
+Stable tag: 1.3.6
 Author: Open Public Media
 Author URI: https://github.com/OpenPublicMedia/
 License: GPLv2
@@ -74,6 +74,10 @@ NPR Stories having been retrieved
 
 
 == Changelog ==
+= V.1.3.6 =
+* Fixed bug that prevented category selection for posts imported via Get Multi queries from saving properly (h/t @xpn-bdivver for the fix)
+* Adding support for pushing multiple post types to the CDS (h/t @justinferrell for the suggestion)
+
 = V.1.3.5 =
 * Switched Yoast plugin detection to work better in multisite setups (h/t @tamw-wnet for the fix)
 

--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,9 @@ NPR Stories having been retrieved
 = V.1.3.7 =
 * Implementing filters for push post type, custom title, custom body, and custom byline (h/t @justinferrell for the suggestion)
 
+= V.1.3.6.1 =
+* Added a check to prevent fatal error on collections with no rels (h/t @tamw-wnet for the fix)
+
 = V.1.3.6 =
 * Fixed bug that prevented category selection for posts imported via Get Multi queries from saving properly (h/t @xpn-bdivver for the fix)
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Tags: npr, news, public radio, api
 Requires at least: 4.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Version: 1.3.6
-Stable tag: 1.3.6
+Version: 1.3.7
+Stable tag: 1.3.7
 Author: Open Public Media
 Author URI: https://github.com/OpenPublicMedia/
 License: GPLv2
@@ -74,6 +74,9 @@ NPR Stories having been retrieved
 
 
 == Changelog ==
+= V.1.3.7 =
+* Implementing filters for push post type, custom title, custom body, and custom byline (h/t @justinferrell for the suggestion)
+
 = V.1.3.6 =
 * Fixed bug that prevented category selection for posts imported via Get Multi queries from saving properly (h/t @xpn-bdivver for the fix)
 

--- a/readme.txt
+++ b/readme.txt
@@ -76,7 +76,6 @@ NPR Stories having been retrieved
 == Changelog ==
 = V.1.3.6 =
 * Fixed bug that prevented category selection for posts imported via Get Multi queries from saving properly (h/t @xpn-bdivver for the fix)
-* Adding support for pushing multiple post types to the CDS (h/t @justinferrell for the suggestion)
 
 = V.1.3.5 =
 * Switched Yoast plugin detection to work better in multisite setups (h/t @tamw-wnet for the fix)

--- a/settings.php
+++ b/settings.php
@@ -473,9 +473,9 @@ function npr_cds_query_callback( $i ): void {
 		$post_types = get_post_types();
 
 		$output = '<div class="npr-cds-query"><h4>Filters</h4><div><p><input type="text" value="' . $query['filters'] . '" name="npr_cds_query_' . $i . '[filters]" placeholder="profileIds=renderable&collectionIds=1002" /></p>' .
-		          '<p><em>A list of available filtering options can be found <a href="https://npr.github.io/content-distribution-service/querying/filtering.html">in the CDS documentation</a></em></p></div>' .
+		          '<p><em>A list of available filtering options can be found <a href="https://npr.github.io/content-distribution-service/api-reference/core-concepts/querying/#filtering">in the CDS documentation</a></em></p></div>' .
 		          '<h4>Sorting</h4><div><p><input type="text" value="' . $query['sorting'] . '" name="npr_cds_query_' . $i . '[sorting]" placeholder="sort=<type>[:<direction>]" /></p>' .
-		          '<p><em>A list of available sorting query parameters can be found <a href="https://npr.github.io/content-distribution-service/querying/sorting.html">in the CDS documentation</a></em></p></div>' .
+		          '<p><em>A list of available sorting query parameters can be found <a href="https://npr.github.io/content-distribution-service/api-reference/core-concepts/querying/#sorting">in the CDS documentation</a></em></p></div>' .
 		          '<h4>Publish or Save as Draft?</h4> ' .
 		          '<div><select id="npr_cds_query_' . $i . '[publish]" name="npr_cds_query_' . $i . '[publish]">' .
 		          '<option value="Publish"' . ( $query['publish'] == 'Publish' ? ' selected' : '' ) . '>Publish</option>' .

--- a/settings.php
+++ b/settings.php
@@ -486,7 +486,7 @@ function npr_cds_query_callback( $i ): void {
 		if ( $optionType == 'post' ) {
 			$args = [
 				'show_option_none'	=> __( 'Select category', 'npr-content-distribution-service' ),
-				'name'				=> 'npr_query_' . $i . '[category]',
+				'name'				=> 'npr_cds_query_' . $i . '[category]',
 				'hierarchical'		=> true,
 				'show_count'		=> 0,
 				'orderby'			=> 'name',

--- a/settings.php
+++ b/settings.php
@@ -387,7 +387,7 @@ function npr_cds_pull_post_type_callback(): void {
 function npr_cds_push_post_type_callback(): void {
 	$post_types = get_post_types();
 	npr_cds_show_post_types_select( 'npr_cds_push_post_type', $post_types );
-	echo npr_cds_esc_html( '<p><em>Hold control (Windows) or Command (macOS) to select multiple post types</em></p><p><em>If you change the Push Post Type setting remember to update the mappings for CDS Fields at <a href="' . admin_url( 'options-general.php?page=npr_cds#npr-fields' ) . '">NPR CDS Field Mapping</a> tab.</em></p>' );
+	echo npr_cds_esc_html( '<p><em>If you change the Push Post Type setting remember to update the mappings for CDS Fields at <a href="' . admin_url( 'options-general.php?page=npr_cds#npr-fields' ) . '">NPR CDS Field Mapping</a> tab.</em></p>' );
 }
 
 function npr_cds_push_default_callback(): void {
@@ -473,9 +473,9 @@ function npr_cds_query_callback( $i ): void {
 		$post_types = get_post_types();
 
 		$output = '<div class="npr-cds-query"><h4>Filters</h4><div><p><input type="text" value="' . $query['filters'] . '" name="npr_cds_query_' . $i . '[filters]" placeholder="profileIds=renderable&collectionIds=1002" /></p>' .
-		          '<p><em>A list of available filtering options can be found <a href="https://npr.github.io/content-distribution-service/querying/filtering.html">in the CDS documentation</a></em></p></div>' .
+		          '<p><em>A list of available filtering options can be found <a href="https://npr.github.io/content-distribution-service/api-reference/core-concepts/querying/#filtering">in the CDS documentation</a></em></p></div>' .
 		          '<h4>Sorting</h4><div><p><input type="text" value="' . $query['sorting'] . '" name="npr_cds_query_' . $i . '[sorting]" placeholder="sort=<type>[:<direction>]" /></p>' .
-		          '<p><em>A list of available sorting query parameters can be found <a href="https://npr.github.io/content-distribution-service/querying/sorting.html">in the CDS documentation</a></em></p></div>' .
+		          '<p><em>A list of available sorting query parameters can be found <a href="https://npr.github.io/content-distribution-service/api-reference/core-concepts/querying/#sorting">in the CDS documentation</a></em></p></div>' .
 		          '<h4>Publish or Save as Draft?</h4> ' .
 		          '<div><select id="npr_cds_query_' . $i . '[publish]" name="npr_cds_query_' . $i . '[publish]">' .
 		          '<option value="Publish"' . ( $query['publish'] == 'Publish' ? ' selected' : '' ) . '>Publish</option>' .
@@ -581,7 +581,7 @@ function npr_cds_mapping_media_agency_callback(): void {
  * @param array $keys - an array like (1=>'Value1', 2=>'Value2', 3=>'Value3');
  */
 function npr_cds_show_post_types_select( string $field_name, array $keys, bool $return = false ): string {
-	$selected = $output = $multi = $multi_note = '';
+	$selected = $output = '';
 	$first_label = 'Select';
 	if ( str_contains( $field_name, 'npr_cds_query_' ) ) {
 		$first_label = 'Default';
@@ -594,34 +594,20 @@ function npr_cds_show_post_types_select( string $field_name, array $keys, bool $
 		}
 	} else {
 		$selected = get_option( $field_name );
-		if ( $field_name == 'npr_cds_push_post_type' ) {
-			$multi = 'multiple ';
-			$field_name .= '[]';
-			if ( !is_array( $selected ) ) {
-				$selected = [ $selected ];
-			}
-		}
-
 	}
 
-	$output .= npr_cds_esc_html( '<div><select ' . $multi . 'id="' . $field_name . '" name="' . $field_name . '">' );
+	$output .= npr_cds_esc_html( '<div><select id="' . $field_name . '" name="' . $field_name . '">' );
 
 	$output .= '<option value=""> &mdash; ' . $first_label . ' &mdash; </option>';
 	foreach ( $keys as $key ) {
 		$option_string = "\n<option  ";
-		if ( is_array( $selected ) ) {
-			if ( in_array( $key, $selected ) ) {
-				$option_string .= " selected ";
-			}
-		} else {
-			if ( $key == $selected ) {
-				$option_string .= " selected ";
-			}
+		if ( $key == $selected ) {
+			$option_string .= " selected ";
 		}
 		$option_string .=   "value='" . esc_attr( $key ) . "'>" . esc_html( $key ) . " </option>";
 		$output .= npr_cds_esc_html( $option_string );
 	}
-	$output .= "</select></div>";
+	$output .= "</select> </div>";
 	if ( !$return ) {
 		echo $output;
 	}
@@ -763,7 +749,7 @@ function npr_cds_show_keys_select( string $field_name, array $keys, bool $return
 }
 
 function npr_cds_get_push_post_type(): string {
-	return get_option( 'npr_cds_push_post_type', ['post'] );
+	return get_option( 'npr_cds_push_post_type', 'post' );
 }
 
 function npr_cds_restore_old(): string {

--- a/settings.php
+++ b/settings.php
@@ -748,10 +748,6 @@ function npr_cds_show_keys_select( string $field_name, array $keys, bool $return
 	return $output;
 }
 
-function npr_cds_get_push_post_type(): string {
-	return get_option( 'npr_cds_push_post_type', 'post' );
-}
-
 function npr_cds_restore_old(): string {
 	$output = '';
 	$old_options = get_option( 'npr_cds_old_options' );


### PR DESCRIPTION
Merge Request QA Checklist

This work updates our custom CDS plugin fork to include the latest changes. CDS plugin from version 1.3.5 to 1.3.7. 

V.1.3.7 -- Implementing filters for push post type, custom title, custom body, and custom byline (h/t @justinferrell for the suggestion)

V.1.3.6.1 -- Added a check to prevent fatal error on collections with no rels (h/t @tamw-wnet for the fix)

V.1.3.6 -- Fixed bug that prevented category selection for posts imported via Get Multi queries from saving properly (h/t @xpn-bdivver for the fix)


[x] Related ticket or issue: https://coloradopublicradio.atlassian.net/browse/DP-593