### PR TITLE
DP-594: Edit crop priority to wide then large then medium

### DIFF
--- a/classes/npr_json.php
+++ b/classes/npr_json.php
@@ -340,12 +340,12 @@ function npr_cds_to_json( $post ): bool|string {
 
 		$image_crops = [ 'large', 'medium', 'npr-cds-wide' ];
 		if ( !empty( $image_meta['sizes'] ) ) {
-			$primary_crop = 'large';
-			if ( empty( $image_meta['sizes']['large'] ) ) {
-				if ( !empty( $image_meta['sizes']['medium'] ) ) {
+			$primary_crop = 'npr-cds-wide';
+			if ( empty( $image_meta['sizes']['npr-cds-wide'] ) ) {
+				if ( !empty( $image_meta['sizes']['large'] ) ) {
+					$primary_crop = 'large';
+				} elseif ( !empty( $image_meta['sizes']['medium'] ) ) {
 					$primary_crop = 'medium';
-				} elseif ( !empty( $image_meta['sizes']['npr-cds-wide'] ) ) {
-					$primary_crop = 'npr-cds-wide';
 				}
 			}
 			foreach ( $image_meta['sizes'] as $key => $value ) {


### PR DESCRIPTION
This ticket ensure that the plugin does tag wide images as priority when they exist and then favorst large > medium images accordingly. 

Details for this ticket can be found here: https://coloradopublicradio.atlassian.net/browse/DP-594. 