### PR TITLE
DP-658: Sync upstream NPR CDS v1.4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A collection of tools for publishing from and to NPR's Content Distribution Serv
 - Requires at least: 4.0
 - Tested up to: 6.9
 - Requires PHP: 8.0
-- Version: 1.4.3
-- Stable tag: 1.4.3
+- Version: 1.4.4
+- Stable tag: 1.4.4
 - Author: Open Public Media
 - Author URI: https://github.com/OpenPublicMedia/
 - License: GPLv2
@@ -81,6 +81,9 @@ Viewing Stories Uploaded to the CDS
 
 ## Changelog
 <!-- copy from readme.txt to here -->
+### V.1.4.4
+* Bug fix in `push_story.php`: changed capability check when saving post metadata from `edit_page` to `edit_post` because the former does not exist
+
 ### V.1.4.3
 * `npr_cds_delete()` now checks if the post type of the post being deleted matches the CDS Push Post Type before any further processing. If so, it then checks user capabilities and potentially errors and dies. Otherwise, it simply returns.
 * Bug fix in Uploaded Stories dashboard when stories have primary images without producer or provider credits

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A collection of tools for publishing from and to NPR's Content Distribution Serv
 - Requires at least: 4.0
 - Tested up to: 6.9
 - Requires PHP: 8.0
-- Version: 1.4.5
-- Stable tag: 1.4.5
+- Version: 1.4.6
+- Stable tag: 1.4.6
 - Author: Open Public Media
 - Author URI: https://github.com/OpenPublicMedia/
 - License: GPLv2
@@ -81,6 +81,9 @@ Viewing Stories Uploaded to the CDS
 
 ## Changelog
 <!-- copy from readme.txt to here -->
+### V.1.4.6
+* CDS Dashboard updated to include NPR app eligibility information
+
 ### V.1.4.5
 * Stories submitted to the CDS can now be featured in the NPR app, which requires a square crop of the images. That new crop is being added and the upload logic updated.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Viewing Stories Uploaded to the CDS
 ## Changelog
 <!-- copy from readme.txt to here -->
 ### V.1.4.3
-* `npr_cds_delete()` now checks if the post type of the post being deleted matches the CDS Push Post Type before any further processing. If so, it then checks user capabilities and potentially errors and dies. Otherwise, it simply returns.  
+* `npr_cds_delete()` now checks if the post type of the post being deleted matches the CDS Push Post Type before any further processing. If so, it then checks user capabilities and potentially errors and dies. Otherwise, it simply returns.
+* Bug fix in Uploaded Stories dashboard when stories have primary images without producer or provider credits
 
 ### V.1.4.2
 * Small tweak to the logic for applying image credits. If the full credit is stored in one field or the agency and credit match, and the credit contains a separator (`/`, `|`, or `,`), then the credit is split and distributed.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A collection of tools for publishing from and to NPR's Content Distribution Serv
 - Contributors: jwcounts, tamw-wnet, bdivver
 - Original developers: NPRDS, INN Labs
 - Requires at least: 4.0
-- Tested up to: 6.8.3
+- Tested up to: 6.9
 - Requires PHP: 8.0
-- Version: 1.4.2
-- Stable tag: 1.4.2
+- Version: 1.4.3
+- Stable tag: 1.4.3
 - Author: Open Public Media
 - Author URI: https://github.com/OpenPublicMedia/
 - License: GPLv2
@@ -81,6 +81,9 @@ Viewing Stories Uploaded to the CDS
 
 ## Changelog
 <!-- copy from readme.txt to here -->
+### V.1.4.3
+* `npr_cds_delete()` now checks if the post type of the post being deleted matches the CDS Push Post Type before any further processing. If so, it then checks user capabilities and potentially errors and dies. Otherwise, it simply returns.  
+
 ### V.1.4.2
 * Small tweak to the logic for applying image credits. If the full credit is stored in one field or the agency and credit match, and the credit contains a separator (`/`, `|`, or `,`), then the credit is split and distributed.
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A collection of tools for publishing from and to NPR's Content Distribution Serv
 - Requires at least: 4.0
 - Tested up to: 6.8.3
 - Requires PHP: 8.0
-- Version: 1.4
-- Stable tag: 1.4
+- Version: 1.4.2
+- Stable tag: 1.4.2
 - Author: Open Public Media
 - Author URI: https://github.com/OpenPublicMedia/
 - License: GPLv2
@@ -81,6 +81,9 @@ Viewing Stories Uploaded to the CDS
 
 ## Changelog
 <!-- copy from readme.txt to here -->
+### V.1.4.2
+* Small tweak to the logic for applying image credits. If the full credit is stored in one field or the agency and credit match, and the credit contains a separator (`/`, `|`, or `,`), then the credit is split and distributed.
+
 ### V.1.4.1
 * Uploaded stories dashboard no longer displays anything if you don't have a valid CDS token, a valid pull URL, or an organization ID
 * Added a check to `npr_cds_push()` to make sure that an organization ID is present before trying to push a story

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Viewing Stories Uploaded to the CDS
 
 ## Changelog
 <!-- copy from readme.txt to here -->
+### V.1.4.1
+* Uploaded stories dashboard no longer displays anything if you don't have a valid CDS token, a valid pull URL, or an organization ID
+* Added a check to `npr_cds_push()` to make sure that an organization ID is present before trying to push a story
+
 ### V.1.4
 * Consolidated all of the admin dashboard pages into a unified menu
 * Added a dashboard to view stories uploaded to the CDS. Contains general publishing information, as well as info on why or why not the story is eligible for the NPR homepage

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A collection of tools for publishing from and to NPR's Content Distribution Serv
 - Requires at least: 4.0
 - Tested up to: 6.9
 - Requires PHP: 8.0
-- Version: 1.4.4
-- Stable tag: 1.4.4
+- Version: 1.4.5
+- Stable tag: 1.4.5
 - Author: Open Public Media
 - Author URI: https://github.com/OpenPublicMedia/
 - License: GPLv2
@@ -81,6 +81,9 @@ Viewing Stories Uploaded to the CDS
 
 ## Changelog
 <!-- copy from readme.txt to here -->
+### V.1.4.5
+* Stories submitted to the CDS can now be featured in the NPR app, which requires a square crop of the images. That new crop is being added and the upload logic updated.
+
 ### V.1.4.4
 * Bug fix in `push_story.php`: changed capability check when saving post metadata from `edit_page` to `edit_post` because the former does not exist
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A collection of tools for publishing from and to NPR's Content Distribution Serv
 - Requires at least: 4.0
 - Tested up to: 6.9
 - Requires PHP: 8.0
-- Version: 1.4.6
-- Stable tag: 1.4.6
+- Version: 1.4.7
+- Stable tag: 1.4.7
 - Author: Open Public Media
 - Author URI: https://github.com/OpenPublicMedia/
 - License: GPLv2
@@ -81,6 +81,9 @@ Viewing Stories Uploaded to the CDS
 
 ## Changelog
 <!-- copy from readme.txt to here -->
+### V.1.4.7
+* CDS Dashboard breaks out homepage and app eligibility information separately
+
 ### V.1.4.6
 * CDS Dashboard updated to include NPR app eligibility information
 

--- a/classes/npr_json.php
+++ b/classes/npr_json.php
@@ -290,14 +290,17 @@ function npr_cds_to_json( $post ): bool|string {
 		}
 
 		if (
-			!empty( $custom_credit ) &&
-			!empty( $custom_agency ) &&
-			$custom_credit == $custom_agency &&
-			( str_contains( $custom_credit, '/' ) || str_contains( $custom_credit, ',' ) )
+			(
+				( !empty( $custom_credit ) && empty( $custom_agency ) ) ||
+				( !empty( $custom_credit ) && !empty( $custom_agency ) && $custom_credit == $custom_agency )
+			) &&
+			( str_contains( $custom_credit, '/' ) || str_contains( $custom_credit, '|' ) || str_contains( $custom_credit, ',' ) )
 		) {
 			$exp_separator = '/';
 			if ( str_contains( $custom_credit, '|' ) ) {
 				$exp_separator = '|';
+			} elseif ( str_contains( $custom_credit, ',' ) ) {
+				$exp_separator = ',';
 			}
 			$parts = explode( $exp_separator, $custom_credit );
 			$custom_credit = trim( $parts[0] );

--- a/classes/npr_json.php
+++ b/classes/npr_json.php
@@ -345,7 +345,7 @@ function npr_cds_to_json( $post ): bool|string {
 		$image_asset->provider = $custom_agency;
 		$image_asset->enclosures = [];
 
-		$image_crops = [ 'large', 'medium', 'npr-cds-wide' ];
+		$image_crops = [ 'large', 'medium', 'npr-cds-wide', 'npr-cds-square' ];
 		if ( !empty( $image_meta['sizes'] ) ) {
 			$primary_crop = 'large';
 			if ( empty( $image_meta['sizes']['large'] ) ) {
@@ -353,6 +353,8 @@ function npr_cds_to_json( $post ): bool|string {
 					$primary_crop = 'medium';
 				} elseif ( !empty( $image_meta['sizes']['npr-cds-wide'] ) ) {
 					$primary_crop = 'npr-cds-wide';
+				} elseif ( !empty( $image_meta['sizes']['npr-cds-square'] ) ) {
+					$primary_crop = 'npr-cds-square';
 				}
 			}
 			foreach ( $image_meta['sizes'] as $key => $value ) {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"type"       : "wordpress-plugin",
 	"license"    : "GPL-2.0+",
 	"dist": {
-		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.4.zip",
+		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.5.zip",
 		"type": "zip"
 	},
 	"authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"type"       : "wordpress-plugin",
 	"license"    : "GPL-2.0+",
 	"dist": {
-		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.zip",
+		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.1.zip",
 		"type": "zip"
 	},
 	"authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"type"       : "wordpress-plugin",
 	"license"    : "GPL-2.0+",
 	"dist": {
-		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.5.zip",
+		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.6.zip",
 		"type": "zip"
 	},
 	"authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"type"       : "wordpress-plugin",
 	"license"    : "GPL-2.0+",
 	"dist": {
-		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.6.zip",
+		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.7.zip",
 		"type": "zip"
 	},
 	"authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"type"       : "wordpress-plugin",
 	"license"    : "GPL-2.0+",
 	"dist": {
-		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.2.zip",
+		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.3.zip",
 		"type": "zip"
 	},
 	"authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"type"       : "wordpress-plugin",
 	"license"    : "GPL-2.0+",
 	"dist": {
-		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.3.zip",
+		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.4.zip",
 		"type": "zip"
 	},
 	"authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"type"       : "wordpress-plugin",
 	"license"    : "GPL-2.0+",
 	"dist": {
-		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.1.zip",
+		"url": "https://github.com/OpenPublicMedia/npr-cds-wordpress/archive/refs/tags/v1.4.2.zip",
 		"type": "zip"
 	},
 	"authors": [

--- a/meta_boxes.php
+++ b/meta_boxes.php
@@ -58,7 +58,7 @@ function npr_cds_publish_meta_box( WP_Post $post ): void {
 			// send to nprone
 			printf(
 				'<li><label><input value="1" type="checkbox" name="_send_to_one" id="_send_to_one" %2$s/> %1$s</label></li>',
-				esc_html__( 'Include for NPR One and NPR homepage', 'npr-content-distribution-service' ),
+				esc_html__( 'Include for NPR One and NPR homepage/app', 'npr-content-distribution-service' ),
 				checked( $push_homepage, '1', false )
 			);
 			printf(

--- a/npr_cds.php
+++ b/npr_cds.php
@@ -3,7 +3,7 @@
  * Plugin Name: NPR Content Distribution Service
  * Plugin URI: https://github.com/OpenPublicMedia/npr-cds-wordpress
  * Description: A collection of tools for reusing content from NPR.org, now maintained and updated by NPR member station developers
- * Version: 1.4.5
+ * Version: 1.4.6
  * Requires at least: 4.0
  * Requires PHP: 8.0
  * Author: Open Public Media

--- a/npr_cds.php
+++ b/npr_cds.php
@@ -3,7 +3,7 @@
  * Plugin Name: NPR Content Distribution Service
  * Plugin URI: https://github.com/OpenPublicMedia/npr-cds-wordpress
  * Description: A collection of tools for reusing content from NPR.org, now maintained and updated by NPR member station developers
- * Version: 1.4
+ * Version: 1.4.1
  * Requires at least: 4.0
  * Requires PHP: 8.0
  * Author: Open Public Media

--- a/npr_cds.php
+++ b/npr_cds.php
@@ -3,7 +3,7 @@
  * Plugin Name: NPR Content Distribution Service
  * Plugin URI: https://github.com/OpenPublicMedia/npr-cds-wordpress
  * Description: A collection of tools for reusing content from NPR.org, now maintained and updated by NPR member station developers
- * Version: 1.4.2
+ * Version: 1.4.3
  * Requires at least: 4.0
  * Requires PHP: 8.0
  * Author: Open Public Media

--- a/npr_cds.php
+++ b/npr_cds.php
@@ -3,7 +3,7 @@
  * Plugin Name: NPR Content Distribution Service
  * Plugin URI: https://github.com/OpenPublicMedia/npr-cds-wordpress
  * Description: A collection of tools for reusing content from NPR.org, now maintained and updated by NPR member station developers
- * Version: 1.4.6
+ * Version: 1.4.7
  * Requires at least: 4.0
  * Requires PHP: 8.0
  * Author: Open Public Media
@@ -13,7 +13,7 @@
  * Text Domain: npr-content-distribution-service
  */
 /*
-	Copyright 2024 Open Public Media
+	Copyright 2026 Open Public Media
 
 	This program is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License, version 2, as

--- a/npr_cds.php
+++ b/npr_cds.php
@@ -3,7 +3,7 @@
  * Plugin Name: NPR Content Distribution Service
  * Plugin URI: https://github.com/OpenPublicMedia/npr-cds-wordpress
  * Description: A collection of tools for reusing content from NPR.org, now maintained and updated by NPR member station developers
- * Version: 1.4.3
+ * Version: 1.4.4
  * Requires at least: 4.0
  * Requires PHP: 8.0
  * Author: Open Public Media

--- a/npr_cds.php
+++ b/npr_cds.php
@@ -3,7 +3,7 @@
  * Plugin Name: NPR Content Distribution Service
  * Plugin URI: https://github.com/OpenPublicMedia/npr-cds-wordpress
  * Description: A collection of tools for reusing content from NPR.org, now maintained and updated by NPR member station developers
- * Version: 1.4.4
+ * Version: 1.4.5
  * Requires at least: 4.0
  * Requires PHP: 8.0
  * Author: Open Public Media
@@ -371,10 +371,11 @@ function npr_cds_create_post_type(): void {
 	]);
 }
 
-add_action( 'init', 'npr_cds_add_wide_image_crops' );
+add_action( 'init', 'npr_cds_add_image_crops' );
 
-function npr_cds_add_wide_image_crops(): void {
+function npr_cds_add_image_crops(): void {
 	add_image_size( 'npr-cds-wide', 1200, 675, [ 'center', 'center' ] );
+	add_image_size( 'npr-cds-square', 600, 600, [ 'center', 'center' ] );
 }
 /**
  * Register the meta box and enqueue its scripts

--- a/npr_cds.php
+++ b/npr_cds.php
@@ -3,7 +3,7 @@
  * Plugin Name: NPR Content Distribution Service
  * Plugin URI: https://github.com/OpenPublicMedia/npr-cds-wordpress
  * Description: A collection of tools for reusing content from NPR.org, now maintained and updated by NPR member station developers
- * Version: 1.4.1
+ * Version: 1.4.2
  * Requires at least: 4.0
  * Requires PHP: 8.0
  * Author: Open Public Media

--- a/push_story.php
+++ b/push_story.php
@@ -222,7 +222,7 @@ function npr_cds_bulk_action_push_action(): void {
 function npr_cds_save_send_to_cds( Int $post_ID ): bool {
 	// safety checks
 	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return false;
-	if ( !current_user_can( 'edit_page', $post_ID ) ) return false;
+	if ( !current_user_can( 'edit_post', $post_ID ) ) return false;
 	if ( empty( $post_ID ) ) return false;
 	if ( !isset( $_POST['npr_cds_send_nonce'] ) || !wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['npr_cds_send_nonce'] ) ), 'npr_cds-' . $post_ID ) ) return false;
 	global $post;
@@ -247,7 +247,7 @@ add_action( 'save_post', 'npr_cds_save_send_to_cds', 15 );
 function npr_cds_save_send_to_one( int $post_ID ): bool {
 	// safety checks
 	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return false;
-	if ( !current_user_can( 'edit_page', $post_ID ) ) return false;
+	if ( !current_user_can( 'edit_post', $post_ID ) ) return false;
 	if ( empty( $post_ID ) ) return false;
 	if ( !isset( $_POST['npr_cds_send_nonce'] ) || !wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['npr_cds_send_nonce'] ) ), 'npr_cds-' . $post_ID ) ) return false;
 
@@ -277,7 +277,7 @@ add_action( 'save_post', 'npr_cds_save_send_to_one', 15 );
 function npr_cds_save_nprone_featured( int $post_ID ): bool {
 	// safety checks
 	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return false;
-	if ( !current_user_can( 'edit_page', $post_ID ) ) return false;
+	if ( !current_user_can( 'edit_post', $post_ID ) ) return false;
 	if ( empty( $post_ID ) ) return false;
 	if ( !isset( $_POST['npr_cds_send_nonce'] ) || !wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['npr_cds_send_nonce'] ) ), 'npr_cds-' . $post_ID ) ) return false;
 
@@ -311,7 +311,7 @@ add_action( 'save_post', 'npr_cds_save_nprone_featured', 15 );
 function npr_cds_save_datetime( int $post_ID ): bool {
 	// safety checks
 	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return false;
-	if ( !current_user_can( 'edit_page', $post_ID ) ) return false;
+	if ( !current_user_can( 'edit_post', $post_ID ) ) return false;
 	if ( empty( $post_ID ) ) return false;
 	if ( !isset( $_POST['npr_cds_send_nonce'] ) || !wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['npr_cds_send_nonce'] ) ), 'npr_cds-' . $post_ID ) ) return false;
 

--- a/push_story.php
+++ b/push_story.php
@@ -88,6 +88,11 @@ function npr_cds_push( int $post_ID, WP_Post $post ): void {
  * @param int $post_ID
  */
 function npr_cds_delete( int $post_ID ): void {
+	$post = get_post( $post_ID );
+	$push_post_type = npr_cds_get_push_post_type( get_post( $post_ID ) );
+	if ( $post->post_type !== $push_post_type ) {
+		return;
+	}
 	if ( !current_user_can( 'delete_others_posts' ) ) {
 		wp_die(
 			__('You do not have permission to delete posts in the NPR CDS. Users that can delete other users\' posts have that ability: administrators and editors.', ),
@@ -95,14 +100,11 @@ function npr_cds_delete( int $post_ID ): void {
 			403
 		);
 	}
-	$push_post_type = npr_cds_get_push_post_type( get_post( $post_ID ) );
-
 	$api_id = get_post_meta( $post_ID, NPR_STORY_ID_META_KEY, true );
 
-	$post = get_post( $post_ID );
 	//if the push url isn't set, don't even try to delete.
 	$push_url = get_option( 'npr_cds_push_url' );
-	if ( $post->post_type == $push_post_type && !empty( $push_url ) && !empty( $api_id ) ) {
+	if ( !empty( $push_url ) && !empty( $api_id ) ) {
 		$api = new NPR_CDS_WP();
 		$retrieved = get_post_meta( $post_ID, NPR_RETRIEVED_STORY_META_KEY, true );
 

--- a/push_story.php
+++ b/push_story.php
@@ -41,6 +41,11 @@ function npr_cds_push( int $post_ID, WP_Post $post ): void {
 		return;
 	}
 
+	$service_id = get_option( 'npr_cds_org_id' );
+	if ( empty( $service_id ) ) {
+		npr_cds_error_log( 'You do not currently have an organization ID set. Please check your settings.' );
+		return;
+	}
 
 	/*
 	 * If there's a custom mapping for the post content,

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Tags: npr, news, public radio, api
 Requires at least: 4.0
 Tested up to: 6.8.3
 Requires PHP: 8.0
-Version: 1.4
-Stable tag: 1.4
+Version: 1.4.1
+Stable tag: 1.4.1
 Author: Open Public Media
 Author URI: https://github.com/OpenPublicMedia/
 License: GPLv2
@@ -74,6 +74,10 @@ NPR Stories having been retrieved
 
 
 == Changelog ==
+= V.1.4.1 =
+* Uploaded stories dashboard no longer displays anything if you don't have a valid CDS token, a valid pull URL, or an organization ID
+* Added a check to `npr_cds_push()` to make sure that an organization ID is present before trying to push a story
+
 = V.1.4 =
 * Consolidated all of the admin dashboard pages into a unified menu
 * Added a dashboard to view stories uploaded to the CDS. Contains general publishing information, as well as info on why or why not the story is eligible for the NPR homepage

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Tags: npr, news, public radio, api
 Requires at least: 4.0
 Tested up to: 6.8.3
 Requires PHP: 8.0
-Version: 1.4.5
-Stable tag: 1.4.5
+Version: 1.4.6
+Stable tag: 1.4.6
 Author: Open Public Media
 Author URI: https://github.com/OpenPublicMedia/
 License: GPLv2
@@ -74,6 +74,9 @@ NPR Stories having been retrieved
 
 
 == Changelog ==
+= V.1.4.6 =
+* CDS Dashboard updated to include NPR app eligibility information
+
 = V.1.4.5 =
 * Stories submitted to the CDS can now be featured in the NPR app, which requires a square crop of the images. That new crop is being added and the upload logic updated.
 

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,7 @@ NPR Stories having been retrieved
 == Changelog ==
 = V.1.4.3 =
 * `npr_cds_delete()` now checks if the post type of the post being deleted matches the CDS Push Post Type before any further processing. If so, it then checks user capabilities and potentially errors and dies. Otherwise, it simply returns.
+* Bug fix in Uploaded Stories dashboard when stories have primary images without producer or provider credits
 
 = V.1.4.2 =
 * Small tweak to the logic for applying image credits. If the full credit is stored in one field or the agency and credit match, and the credit contains a separator (`/`, `|`, or `,`), then the credit is split and distributed.

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Tags: npr, news, public radio, api
 Requires at least: 4.0
 Tested up to: 6.8.3
 Requires PHP: 8.0
-Version: 1.4.2
-Stable tag: 1.4.2
+Version: 1.4.4
+Stable tag: 1.4.4
 Author: Open Public Media
 Author URI: https://github.com/OpenPublicMedia/
 License: GPLv2
@@ -74,6 +74,9 @@ NPR Stories having been retrieved
 
 
 == Changelog ==
+= V.1.4.4 =
+* Bug fix in `push_story.php`: changed capability check when saving post metadata from `edit_page` to `edit_post` because the former does not exist
+
 = V.1.4.3 =
 * `npr_cds_delete()` now checks if the post type of the post being deleted matches the CDS Push Post Type before any further processing. If so, it then checks user capabilities and potentially errors and dies. Otherwise, it simply returns.
 * Bug fix in Uploaded Stories dashboard when stories have primary images without producer or provider credits

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Tags: npr, news, public radio, api
 Requires at least: 4.0
 Tested up to: 6.8.3
 Requires PHP: 8.0
-Version: 1.4.4
-Stable tag: 1.4.4
+Version: 1.4.5
+Stable tag: 1.4.5
 Author: Open Public Media
 Author URI: https://github.com/OpenPublicMedia/
 License: GPLv2
@@ -74,6 +74,9 @@ NPR Stories having been retrieved
 
 
 == Changelog ==
+= V.1.4.5 =
+* Stories submitted to the CDS can now be featured in the NPR app, which requires a square crop of the images. That new crop is being added and the upload logic updated.
+
 = V.1.4.4 =
 * Bug fix in `push_story.php`: changed capability check when saving post metadata from `edit_page` to `edit_post` because the former does not exist
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Tags: npr, news, public radio, api
 Requires at least: 4.0
 Tested up to: 6.8.3
 Requires PHP: 8.0
-Version: 1.4.1
-Stable tag: 1.4.1
+Version: 1.4.2
+Stable tag: 1.4.2
 Author: Open Public Media
 Author URI: https://github.com/OpenPublicMedia/
 License: GPLv2
@@ -74,6 +74,9 @@ NPR Stories having been retrieved
 
 
 == Changelog ==
+= V.1.4.2 =
+* Small tweak to the logic for applying image credits. If the full credit is stored in one field or the agency and credit match, and the credit contains a separator (`/`, `|`, or `,`), then the credit is split and distributed.
+
 = V.1.4.1 =
 * Uploaded stories dashboard no longer displays anything if you don't have a valid CDS token, a valid pull URL, or an organization ID
 * Added a check to `npr_cds_push()` to make sure that an organization ID is present before trying to push a story

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,9 @@ NPR Stories having been retrieved
 
 
 == Changelog ==
+= V.1.4.3 =
+* `npr_cds_delete()` now checks if the post type of the post being deleted matches the CDS Push Post Type before any further processing. If so, it then checks user capabilities and potentially errors and dies. Otherwise, it simply returns.
+
 = V.1.4.2 =
 * Small tweak to the logic for applying image credits. If the full credit is stored in one field or the agency and credit match, and the credit contains a separator (`/`, `|`, or `,`), then the credit is split and distributed.
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Tags: npr, news, public radio, api
 Requires at least: 4.0
 Tested up to: 6.8.3
 Requires PHP: 8.0
-Version: 1.4.6
-Stable tag: 1.4.6
+Version: 1.4.7
+Stable tag: 1.4.7
 Author: Open Public Media
 Author URI: https://github.com/OpenPublicMedia/
 License: GPLv2
@@ -74,6 +74,9 @@ NPR Stories having been retrieved
 
 
 == Changelog ==
+= V.1.4.7 =
+* CDS Dashboard breaks out homepage and app eligibility information separately
+
 = V.1.4.6 =
 * CDS Dashboard updated to include NPR app eligibility information
 

--- a/settings.php
+++ b/settings.php
@@ -1356,11 +1356,17 @@ class NPR_CDS {
 									$image_src = $enclosure->href;
 								}
 							}
+							$image_producer_provider = '';
 							if ( !empty( $image_asset->producer ) ) {
 								$homepage_eligible['image-producer-credit'] = 'Yes';
+								$image_producer_provider = $image_asset->producer;
+							}
+							if ( !empty( $image_producer_provider ) ) {
+								$image_producer_provider .= ' / ';
 							}
 							if ( !empty( $image_asset->provider ) ) {
 								$homepage_eligible['image-provider-credit'] = 'Yes';
+								$image_producer_provider .= $image_asset->provider;
 							}
 
 							$primary_image = <<<EOT
@@ -1370,7 +1376,7 @@ class NPR_CDS {
 										<ul>
 											<li><strong>Profile:</strong> {$main_rel}</li>
 											<li><strong>Caption:</strong> {$image_asset->caption}</li>
-											<li><strong>Credit:</strong> {$image_asset->producer} / {$image_asset->provider}</li>
+											<li><strong>Credit:</strong> {$image_producer_provider}</li>
 										</ul>
 									</div>
 									<div>

--- a/settings.php
+++ b/settings.php
@@ -1288,6 +1288,7 @@ class NPR_CDS {
 					'collection' => 'No',
 					'publish-time' => 'No',
 					'image-wide-primary' => 'No',
+					'image-square-primary' => 'No',
 					'image-producer-credit' => 'No',
 					'image-provider-credit' => 'No',
 					'teaser' => 'No'
@@ -1355,6 +1356,9 @@ class NPR_CDS {
 								if ( in_array( 'primary', $enclosure->rels ) ) {
 									$image_src = $enclosure->href;
 								}
+								if ( in_array( 'image-square', $enclosure->rels ) ) {
+									$homepage_eligible['image-square-primary'] = 'Yes';
+								}
 							}
 							$image_producer_provider = '';
 							if ( !empty( $image_asset->producer ) ) {
@@ -1394,6 +1398,7 @@ EOT;
 					$homepage_eligible['collection'] == 'Yes' &&
 					$homepage_eligible['publish-time'] == 'Yes' &&
 					$homepage_eligible['image-wide-primary'] == 'Yes' &&
+					$homepage_eligible['image-square-primary'] == 'Yes' &&
 					$homepage_eligible['image-producer-credit'] == 'Yes' &&
 					$homepage_eligible['image-provider-credit'] == 'Yes' &&
 					$homepage_eligible['teaser'] == 'Yes'
@@ -1413,6 +1418,7 @@ EOT;
 							<li class="homepage-{$homepage_eligible['publish-time']}">was published < 72 hours ago? <strong>{$homepage_eligible['publish-time']}</strong></li>
 							<li class="homepage-{$homepage_eligible['teaser']}">has a teaser/description with no formatting? <strong>{$homepage_eligible['teaser']}</strong></li>
 							<li class="homepage-{$homepage_eligible['image-wide-primary']}">has a wide primary image? <strong>{$homepage_eligible['image-wide-primary']}</strong></li>
+							<li class="homepage-{$homepage_eligible['image-square-primary']}">has a square crop of the primary image? <strong>{$homepage_eligible['image-square-primary']}</strong></li>
 							<li class="homepage-{$homepage_eligible['image-producer-credit']}">has an image producer/source? <strong>{$homepage_eligible['image-producer-credit']}</strong></li>
 							<li class="homepage-{$homepage_eligible['image-provider-credit']}">has an image provider/credit? <strong>{$homepage_eligible['image-provider-credit']}</strong></li>
 						</ul>
@@ -1424,7 +1430,7 @@ EOT;
 						<div class="cds-summary">
 							<div>{$story->title}</div>
 							<div>Published:<br><strong>{$publishTime}</strong></div>
-							<div>NPR Homepage Eligible:<br><strong>{$homepage_eligible['overall']}</strong></div>
+							<div>NPR Homepage/App Eligible:<br><strong>{$homepage_eligible['overall']}</strong></div>
 						</div>
 					</summary>
 					<div class="npr-grid">
@@ -1443,7 +1449,7 @@ EOT;
 							<p>Last Modified Date:<br><strong>{$lastModified}</strong></p>
 							<p><strong><a href="{$edit_link}">Edit in WordPress</a></strong></p>
 							<div class="npr-homepage">
-								<p class="homepage-eligible">NPR Homepage Eligible: <strong>{$homepage_eligible['overall']}</strong></p>
+								<p class="homepage-eligible">NPR Homepage/App Eligible: <strong>{$homepage_eligible['overall']}</strong></p>
 								{$homepage}
 							</div>
 						</div>

--- a/settings.php
+++ b/settings.php
@@ -1094,11 +1094,19 @@ class NPR_CDS {
 	public function view_uploads(): void {
 		$api_key = NPR_CDS_WP::get_cds_token();
 		$pull_url = NPR_CDS_PULL_URL;
+		$service_id = get_option( 'npr_cds_org_id' );
+		$valid = true;
 		if ( !$api_key ) {
 			npr_cds_show_message( 'You do not currently have a CDS token set. <a href="' . admin_url( 'admin.php?page=npr-cds-settings' ) . '">Set your CDS token here.</a>', TRUE );
+			$valid = false;
 		}
 		if ( !$pull_url ) {
 			npr_cds_show_message( 'You do not currently have a CDS Pull URL set. <a href="' . admin_url( 'admin.php?page=npr-cds-settings' ) . '">Set your CDS Pull URL here.</a>', TRUE );
+			$valid = false;
+		}
+		if ( empty( $service_id ) ) {
+			npr_cds_show_message( 'You do not currently have an organization ID set. <a href="' . admin_url( 'admin.php?page=npr-cds-settings' ) . '">Set your organization ID here.</a>', TRUE );
+			$valid = false;
 		} ?>
 		<style>
 			details {
@@ -1226,6 +1234,10 @@ class NPR_CDS {
 		<div class="wrap">
 			<h1>NPR CDS: View Uploaded Stories</h1>
 		<?php
+		if ( !$valid ) {
+			echo "</div>";
+			return;
+		}
 		$offset = 0;
 		if ( !empty( $_GET['cds_offset'] ) ) {
 			$get_offset = sanitize_text_field( $_GET['cds_offset'] );
@@ -1254,8 +1266,6 @@ class NPR_CDS {
 		}
 		echo '</p>';
 		$api = new NPR_CDS_WP();
-
-		$service_id = get_option( 'npr_cds_org_id' );
 		$service_ids = explode( ',', $service_id );
 		$owners = [];
 		foreach( $service_ids as $oi ) {

--- a/settings.php
+++ b/settings.php
@@ -1284,7 +1284,8 @@ class NPR_CDS {
 		if ( empty( $api->message ) ) {
 			foreach ( $api->stories as $story ) {
 				$homepage_eligible = [
-					'overall' => 'No',
+					'homepage' => 'No',
+					'app' => 'No',
 					'collection' => 'No',
 					'publish-time' => 'No',
 					'image-wide-primary' => 'No',
@@ -1398,17 +1399,24 @@ EOT;
 					$homepage_eligible['collection'] == 'Yes' &&
 					$homepage_eligible['publish-time'] == 'Yes' &&
 					$homepage_eligible['image-wide-primary'] == 'Yes' &&
-					$homepage_eligible['image-square-primary'] == 'Yes' &&
 					$homepage_eligible['image-producer-credit'] == 'Yes' &&
 					$homepage_eligible['image-provider-credit'] == 'Yes' &&
 					$homepage_eligible['teaser'] == 'Yes'
 				) {
-					$homepage_eligible['overall'] = 'Yes';
+					$homepage_eligible['homepage'] = 'Yes';
+					if ( $homepage_eligible['image-square-primary'] == 'Yes' ) {
+						$homepage_eligible['app'] = 'Yes';
+					}
 				}
 				$profiles = implode( ', ', $profiles_arr );
 				$owners = implode( ', ', $owners_arr );
 				$collections = implode( ', ', $collect_arr );
 				$bylines = implode( ', ', $bylines_arr );
+				$homepage_app = $homepage_eligible['homepage'] . ' / ' . $homepage_eligible['app'];
+				if ( $homepage_eligible['app'] === $homepage_eligible['homepage'] ) {
+					$homepage_app = $homepage_eligible['app'];
+				}
+
 				$homepage = <<<EOT
 					<details class="npr-homepage-eligible">
 						<summary>Why?</summary>
@@ -1430,7 +1438,7 @@ EOT;
 						<div class="cds-summary">
 							<div>{$story->title}</div>
 							<div>Published:<br><strong>{$publishTime}</strong></div>
-							<div>NPR Homepage/App Eligible:<br><strong>{$homepage_eligible['overall']}</strong></div>
+							<div>NPR Homepage/App Eligible:<br><strong>{$homepage_app}</strong></div>
 						</div>
 					</summary>
 					<div class="npr-grid">
@@ -1449,7 +1457,7 @@ EOT;
 							<p>Last Modified Date:<br><strong>{$lastModified}</strong></p>
 							<p><strong><a href="{$edit_link}">Edit in WordPress</a></strong></p>
 							<div class="npr-homepage">
-								<p class="homepage-eligible">NPR Homepage/App Eligible: <strong>{$homepage_eligible['overall']}</strong></p>
+								<p class="homepage-eligible">NPR Homepage/App Eligible: <strong>{$homepage_app}</strong></p>
 								{$homepage}
 							</div>
 						</div>


### PR DESCRIPTION
Upstream changes getting merged:
- v1.4.7: CDS Dashboard breaks out homepage and app eligibility
- v1.4.6: NPR app eligibility information added
- v1.4.5: Square crop support for NPR app
- v1.4.4: Bug fix - capability check `edit_page` → `edit_post`
- v1.4.3: `npr_cds_delete()` post type checking
- v1.4.2: Image credit splitting logic improvements
- v1.4.1: Organization ID validation & dashboard improvements